### PR TITLE
nette 2.4 compatibility change

### DIFF
--- a/FormFactoryBuilder/formBuilder.neon
+++ b/FormFactoryBuilder/formBuilder.neon
@@ -10,4 +10,5 @@ services:
 	formBuilder.loader:
 		class: \Arron\FormBuilder\CachedLoader(@formBuilder.builder, @formBuilder.sourceCodeCache)
 
-	formBuilder.builder < formBuilder.neonBuilder:
+	formBuilder.builder:
+	        class: \Arron\FormBuilder\NeonBuilder(@formBuilder.arrayBuilder, \Nette\Neon\Decoder())


### PR DESCRIPTION
nette 2.4 deprecates this:
Section inheritance formBuilder.builder < formBuilder.neonBuilder is deprecated